### PR TITLE
feat(movies): Add list movies endpoint.

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -8,3 +8,24 @@ exports.create = (payload) => {
     return new Movie({ id: movie.id }).fetch();
   });
 };
+
+exports.list = (filter) => {
+  let sortProperty = null;
+  let sortDirection = null;
+  const query = filter.q;
+
+  if (filter.sort.charAt(0) === '-') {
+    sortProperty = filter.sort.slice(1);
+    sortDirection = 'DESC';
+  } else {
+    sortProperty = filter.sort;
+    sortDirection = 'ASC';
+  }
+
+  return new Movie()
+  .query((qb) => {
+    qb.whereRaw('lower(title) LIKE ?', `%${query}%`);
+  })
+  .orderBy(sortProperty, sortDirection)
+  .fetchAll();
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,9 +1,29 @@
 'use strict';
 
-const Controller     = require('./controller');
-const MovieValidator = require('../../../validators/movie');
+const Controller           = require('./controller');
+const MovieCreateValidator = require('../../../validators/movieCreate');
+const MovieListValidator   = require('../../../validators/movieList');
 
 exports.register = (server, options, next) => {
+
+  server.route([{
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: function (request, reply) {
+        return Controller.list(request.query)
+        .then((movieList) => {
+          return reply({
+            count: movieList.length,
+            data: movieList
+          });
+        });
+      },
+      validate: {
+        query: MovieListValidator
+      }
+    }
+  }]);
 
   server.route([{
     method: 'POST',
@@ -13,7 +33,7 @@ exports.register = (server, options, next) => {
         reply(Controller.create(request.payload));
       },
       validate: {
-        payload: MovieValidator
+        payload: MovieCreateValidator
       }
     }
   }]);

--- a/lib/validators/movieCreate.js
+++ b/lib/validators/movieCreate.js
@@ -4,5 +4,5 @@ const Joi = require('joi');
 
 module.exports = Joi.object().keys({
   title: Joi.string().min(1).max(255).required(),
-  release_year: Joi.number().min(1878).max(9999).optional()
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
 });

--- a/lib/validators/movieList.js
+++ b/lib/validators/movieList.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  sort: Joi.string().valid(['id', 'title', 'release_year', '-id', '-title', '-release_year']).optional().default('id'),
+  q: Joi.string().optional().default('').lowercase()
+}).optional().default({});

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Knex = require('../lib/libraries/knex');
+
+beforeEach(() => {
+  return Knex('movies').truncate();
+});

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -2,8 +2,17 @@
 
 const Controller = require('../../../../lib/plugins/features/movies/controller');
 const Movie      = require('../../../../lib/models/movie');
+const Knex       = require('../../../../lib/libraries/knex');
+
+const firstMovie  = { title: 'The Prestige', release_year: 2006 };
+const secondMovie = { title: 'Memento' };
+const thirdMovie  = { title: 'The Departed', release_year: 2006 };
 
 describe('movie controller', () => {
+
+  beforeEach(() => {
+    return Knex('movies').insert([firstMovie, secondMovie, thirdMovie]);
+  });
 
   describe('create', () => {
 
@@ -34,6 +43,73 @@ describe('movie controller', () => {
       .then((movie) => {
         expect(movie.get('title')).to.eql(payload.title);
         expect(movie.get('release_year')).to.eql(payload.release_year);
+      });
+    });
+
+  });
+
+  describe('list', () => {
+
+    it('should properly sort based on query params', () => {
+      const query = { sort: 'release_year' , q: '' };
+      const reverseQuery = { sort: '-release_year', q: '' };
+
+      Controller.list(query)
+      .then((movies) => {
+        let ordered = true;
+
+        expect(movies.length).to.be.at.least(1);
+
+        movies.each((movie, index) => {
+          if (!movie.release_year || !movies[index + 1].release_year) {
+            return;
+          }
+
+          if (movie.release_year < movies[index + 1].release_year) {
+            ordered = false;
+          }
+        });
+
+        expect(ordered).to.be.true;
+      });
+
+      return Controller.list(reverseQuery)
+      .then((movies) => {
+        let ordered = true;
+
+        expect(movies.length).to.be.at.least(1);
+
+        movies.each((movie, index) => {
+          if (!movie.release_year || !movies[index + 1].release_year) {
+            return;
+          }
+
+          if (movie.release_year > movies[index + 1].release_year) {
+            ordered = false;
+          }
+        });
+
+        expect(ordered).to.be.true;
+      });
+    });
+
+    it('should filter titles based request query', () => {
+      const q = 'amer';
+      const query = { q, sort: 'release_year' };
+
+      Controller.list(query)
+      .then((movies) => {
+        let filtered = true;
+
+        expect(movies.length).to.be.at.least(1);
+
+        movies.each((movie) => {
+          if (!movie.match(q)) {
+            filtered = false;
+          }
+        });
+
+        expect(filtered).to.be.true;
       });
     });
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,8 +1,17 @@
 'use strict';
 
 const Movies = require('../../../../lib/server');
+const Knex   = require('../../../../lib/libraries/knex');
+
+const firstMovie  = { title: 'The Prestige', release_year: 2006 };
+const secondMovie = { title: 'Memento' };
+const thirdMovie  = { title: 'The Departed', release_year: 2006 };
 
 describe('movies integration', () => {
+
+  beforeEach(() => {
+    return Knex('movies').insert([firstMovie, secondMovie, thirdMovie]);
+  });
 
   describe('create', () => {
 
@@ -15,6 +24,22 @@ describe('movies integration', () => {
       .then((response) => {
         expect(response.statusCode).to.eql(200);
         expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+  describe('list', () => {
+
+    it('lists all movies', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.have.property('count');
+        expect(response.result).to.have.property('data');
       });
     });
 

--- a/test/validators/movieCreate.test.js
+++ b/test/validators/movieCreate.test.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 
-const MovieValidator = require('../../lib/validators/movie');
+const MovieCreateValidator = require('../../lib/validators/movieCreate');
 
 describe('movie validator', () => {
 
@@ -10,7 +10,7 @@ describe('movie validator', () => {
 
     it('is required', () => {
       const payload = {};
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieCreateValidator);
 
       expect(result.error.details[0].path).to.eql('title');
       expect(result.error.details[0].type).to.eql('any.required');
@@ -18,7 +18,7 @@ describe('movie validator', () => {
 
     it('is not empty', () => {
       const payload = { title: '' };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieCreateValidator);
 
       expect(result.error.details[0].path).to.eql('title');
       expect(result.error.details[0].type).to.eql('any.empty');
@@ -26,7 +26,7 @@ describe('movie validator', () => {
 
     it('is less than 255 characters', () => {
       const payload = { title: 'a'.repeat(260) };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieCreateValidator);
 
       expect(result.error.details[0].path).to.eql('title');
       expect(result.error.details[0].type).to.eql('string.max');
@@ -41,7 +41,7 @@ describe('movie validator', () => {
         title: 'foo',
         release_year: 1800
       };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieCreateValidator);
 
       expect(result.error.details[0].path).to.eql('release_year');
       expect(result.error.details[0].type).to.eql('number.min');
@@ -52,7 +52,7 @@ describe('movie validator', () => {
         title: 'foo',
         release_year: 12345
       };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieCreateValidator);
 
       expect(result.error.details[0].path).to.eql('release_year');
       expect(result.error.details[0].type).to.eql('number.max');

--- a/test/validators/movieList.test.js
+++ b/test/validators/movieList.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieListValidator = require('../../lib/validators/movieList');
+
+describe('movie query validator', () => {
+
+  describe('sort', () => {
+
+    it('rejects incorrect keys', () => {
+      const query = { sort: 'false_key' };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error.details[0].path).to.eql('sort');
+      expect(result.error.details[0].type).to.eql('any.allowOnly');
+    });
+
+    it('is optional', () => {
+      const query = { };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error).to.be.null;
+    });
+
+    it('is given a default value when not provided', () => {
+      const query = { };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.value.sort).to.eql('id');
+    });
+
+  });
+
+  describe('q', () => {
+
+    it('is forced to lowercase', () => {
+      const q = 'QUERY_VALUE';
+      const query = { q };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.value.q).to.eql(q.toLowerCase());
+    });
+
+    it('is optional', () => {
+      const query = { };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.error).to.be.null;
+    });
+
+    it('is given a default value when not provided', () => {
+      const query = { };
+      const result = Joi.validate(query, MovieListValidator);
+
+      expect(result.value.q).to.eql('');
+    });
+
+  });
+
+});


### PR DESCRIPTION
What: Add an endpoint that lists movies, orders them by user-specified properties, and filters them by title.

Why: Users should be able to easily query the movie registry and find movies based on their search parameters.
