### PR TITLE
Add movie validators.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -13,7 +13,11 @@ const server = new Hapi.Server({
 server.connection({ port: Config.PORT });
 
 server.register([
-  require('hapi-bookshelf-serializer')
+  require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  }
 ], (err) => {
   /* istanbul ignore if */
   if (err) {

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "bookshelf": "^0.10.4",
     "hapi": "^16.5.2",
     "hapi-bookshelf-serializer": "^2.1.0",
+    "hapi-format-error": "^1.1.0",
+    "joi": "^10.6.0",
     "knex": "^0.13.0",
     "pg": "^7.1.2"
   },

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  it('succeeds when all allowed params are included', () => {
+    const title = 'title';
+    const release_year = 2017;
+    const payload = { title, release_year };
+    const result = Joi.validate(payload, MovieValidator);
+
+    expect(result.error).to.be.null;
+  });
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is less than 255 characters', () => {
+      const title = 'a'.repeat(256);
+      const payload = { title };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+    it('is nonempty', () => {
+      const title = '';
+      const payload = { title };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.empty');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const title = 'Dom The Bomb';
+      const release_year = 1877;
+      const payload = { title, release_year };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const title = 'Dom The Bomb 2: Domlectric Boogaloo';
+      const release_year = 10000;
+      const payload = { title, release_year };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is optional', () => {
+      const title = 'Dom 3 Bomb';
+      const payload = { title };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error).to.be.null;
+    });
+
+    it('is limited to integers', () => {
+      const title = 'Dom Fast Dom 4ious';
+      const release_year = 2017.89;
+      const payload = { title, release_year };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,10 @@ hapi-bookshelf-serializer@^2.1.0:
     bluebird "^2.9.34"
     boom "^2.8.0"
 
+hapi-format-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-format-error/-/hapi-format-error-1.1.0.tgz#28d97f82b40f1b1d1b62b0215eab1cdfe983bbde"
+
 hapi@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.5.2.tgz#d1dadf33721c6ac3aaa905ce086d9c7ffb883092"


### PR DESCRIPTION
**¿Qué?**: Create Joi validation objects for movie payloads.

**¿Por qué?**: We want to disallow extraneous, incomplete, or strategically malicious request payloads from being received by the movies API.