### PR TITLE
Add `name` column to database

### DIFF
--- a/db/migrations/20170820012248_add_name_to_movies.js
+++ b/db/migrations/20170820012248_add_name_to_movies.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => table.text('name'))
+  .then(() => Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL'));
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => table.dropColumn('name'))
+  .then(() => Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL'));
+};


### PR DESCRIPTION
What: Add `name` column to database.

Why: Our end goal is to change the `title` value to `name` while incurring zero downtime.