### PR TITLE
Save movie name to database alongside movie title.

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,6 +3,7 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
+  payload.name = payload.title;
   return new Movie().save(payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };


### PR DESCRIPTION
What: Save movie name to database for each movie created.

Why: The end goal is to eventually move away from movie `title` and towards movie `name`.

Note: This is PR 2/5 in the migration to switch `title` to `name` in the DB. It may seem short, but the purpose is to incur zero downtime with the API.