### PR TITLE
Backfill name column of movies DB with movie titles.

### DIFF
--- a/db/migrations/20170820012659_backfill_movies_name.js
+++ b/db/migrations/20170820012659_backfill_movies_name.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.up = (Knex) => Knex.raw('UPDATE movies SET name = title');
+
+exports.down = (Knex, Promise) => Promise.resolve();


### PR DESCRIPTION
What: Fill name column of movies DB with movie titles.

Why: The end goal here is to eventually switch from `title` to `name`.