### PR TITLE
Drop movie title column

### DIFF
--- a/db/migrations/20170820014109_drop_title_from_movies.js
+++ b/db/migrations/20170820014109_drop_title_from_movies.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => table.dropColumn('title'))
+  .then(() => Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL'));
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => table.text('title'))
+  .then(() => Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL'));
+};


### PR DESCRIPTION
What: Drop movie title column

Why: To successfully complete the switch from `title` to `name`.