### PR TITLE
Add validator for movie list endpoint

### DIFF
--- a/lib/validators/movies/list.js
+++ b/lib/validators/movies/list.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  name: Joi.string().min(1).max(255).optional(),
+  release_year: Joi.alternatives().try(
+    Joi.number().min(1).optional(),
+    Joi.object().keys({
+      lt: Joi.number().min(1).optional(),
+      lte: Joi.number().min(1).optional(),
+      gt: Joi.number().min(1).optional(),
+      gte: Joi.number().min(1).optional()
+    }).optional()
+  ).optional()
+}).optional();

--- a/test/validators/movies/list.test.js
+++ b/test/validators/movies/list.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieListValidator = require('../../../lib/validators/movies/list');
+
+describe('movie list validator', () => {
+
+  it('succeeds when all allowed params are included', () => {
+    const name = 'title';
+    const release_year = {
+      gt: 2000,
+      lt: 2017
+    };
+    const payload = { name, release_year };
+    const result = Joi.validate(payload, MovieListValidator);
+
+    expect(result.error).to.be.null;
+  });
+
+  describe('name', () => {
+
+    it('is optional', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error).to.be.null;
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('can be an object', () => {
+      const release_year = { gt: 1877 };
+      const payload = { release_year };
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error).to.be.null;
+    });
+
+    it('can be a number', () => {
+      const release_year = 1877;
+      const payload = { release_year };
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error).to.be.null;
+    });
+
+  });
+
+});


### PR DESCRIPTION
**What:** Add validator for movie list endpoint.

**Why:** This validator defines the structure of the query object that will be used to filter the movie `findAll` results.